### PR TITLE
custom to use any elements tagName

### DIFF
--- a/dist/js/jquery.dragsort.js
+++ b/dist/js/jquery.dragsort.js
@@ -31,7 +31,7 @@
 
                 init: function () {
                     //set options to default values if not set
-                    opts.tagName = $(this.container).children().length == 0 ? 'li' : $(this.container).children().get(0).tagName.toLowerCase();
+                    opts.tagName = opts.tagName || $(this.container).children().length == 0 ? 'li' : $(this.container).children().get(0).tagName.toLowerCase();
                     if (!opts.itemSelector) {
                         opts.itemSelector = opts.tagName;
                     }
@@ -431,6 +431,7 @@
     };
 
     $.fn.dragsort.defaults = {
+        tagName: '',
         itemSelector: '',
         dragSelector: '',
         dragSelectorExclude: 'input, textarea',


### PR DESCRIPTION
in the initialization,  because the `$('#wrap').children().length === 0` , so we only get the `opts.tagName = 'li'` but actually is `div` , it should be custom the `tagName`. or other better than this solution.(good library, helpful for me)

```html
<div id="wrap"></div>
```
```js
$('#wrap').dragsort();
```